### PR TITLE
2.2.x rev.1

### DIFF
--- a/client/src/lib/settings-access.test.ts
+++ b/client/src/lib/settings-access.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  canManageCustomDomainSettings,
+  hasPremiumSettingsAccess,
+  isSettingsBillingPending,
+} from './settings-access.ts';
+
+test('settings billing stays pending until billing data exists', () => {
+  assert.equal(isSettingsBillingPending(undefined, true), true);
+  assert.equal(
+    isSettingsBillingPending(
+      {
+        plan: 'PREMIUM',
+        subscriptionStatus: 'ACTIVE',
+        currentPeriodEnd: '2099-01-01T00:00:00.000Z',
+      },
+      true
+    ),
+    false
+  );
+});
+
+test('premium access is only granted after billing status resolves', () => {
+  assert.equal(hasPremiumSettingsAccess(undefined), false);
+  assert.equal(
+    hasPremiumSettingsAccess({
+      plan: 'PREMIUM',
+      subscriptionStatus: 'ACTIVE',
+      currentPeriodEnd: '2099-01-01T00:00:00.000Z',
+    }),
+    true
+  );
+});
+
+test('custom domain access respects grandfathered servers after billing resolves', () => {
+  assert.equal(canManageCustomDomainSettings(undefined), false);
+  assert.equal(
+    canManageCustomDomainSettings({
+      plan: 'FREE',
+      subscriptionStatus: 'INACTIVE',
+      customDomainGrandfathered: true,
+    }),
+    true
+  );
+});

--- a/client/src/lib/settings-access.ts
+++ b/client/src/lib/settings-access.ts
@@ -1,0 +1,39 @@
+import { hasPremiumAccess } from './backend-enums.ts';
+
+interface BillingStatusSnapshot {
+  plan?: string | null;
+  subscriptionStatus?: string | null;
+  currentPeriodEnd?: string | Date | null;
+  customDomainGrandfathered?: boolean | null;
+}
+
+export function isSettingsBillingPending(
+  billingStatus: BillingStatusSnapshot | undefined,
+  isBillingLoading: boolean
+): boolean {
+  return isBillingLoading && !billingStatus;
+}
+
+export function hasPremiumSettingsAccess(
+  billingStatus: BillingStatusSnapshot | undefined
+): boolean {
+  if (!billingStatus) {
+    return false;
+  }
+
+  return hasPremiumAccess({
+    plan: billingStatus.plan,
+    subscriptionStatus: billingStatus.subscriptionStatus,
+    currentPeriodEnd: billingStatus.currentPeriodEnd,
+  });
+}
+
+export function canManageCustomDomainSettings(
+  billingStatus: BillingStatusSnapshot | undefined
+): boolean {
+  if (!billingStatus) {
+    return false;
+  }
+
+  return hasPremiumSettingsAccess(billingStatus) || Boolean(billingStatus.customDomainGrandfathered);
+}

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -6,6 +6,7 @@ import { setDateLocale, setDateFormat as setDateFormatUtil } from '@/utils/date-
 import i18n from '@/lib/i18n';
 import { Button } from '@modl-gg/shared-web/components/ui/button';
 import { Card, CardContent } from '@modl-gg/shared-web/components/ui/card';
+import { Skeleton } from '@modl-gg/shared-web/components/ui/skeleton';
 import { useSidebar } from '@/hooks/use-sidebar';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@modl-gg/shared-web/components/ui/tabs';
 import { Switch } from '@modl-gg/shared-web/components/ui/switch';
@@ -43,6 +44,11 @@ import {
   hasPremiumAccess,
   normalizeSubscriptionStatus,
 } from '@/lib/backend-enums';
+import {
+  canManageCustomDomainSettings,
+  hasPremiumSettingsAccess,
+  isSettingsBillingPending,
+} from '@/lib/settings-access';
 import {
   AppealFormField,
   AppealFormSection,
@@ -704,20 +710,22 @@ const Settings = () => {
   const mainContentClass = "ml-[32px] pl-8";
   const [expandedCategory, setExpandedCategory] = useState<string | null>(null);
   const [expandedSubCategory, setExpandedSubCategory] = useState<string | null>(null);
-  const { data: billingStatusTop } = useBillingStatus();
+  const {
+    data: billingStatus,
+    isLoading: isBillingStatusLoading,
+    isFetching: isFetchingBillingStatus,
+  } = useBillingStatus();
+  const isBillingAccessPending = isSettingsBillingPending(
+    billingStatus,
+    isBillingStatusLoading || isFetchingBillingStatus
+  );
 
   const isPremiumUser = () => {
-    if (!billingStatusTop) return false;
-    return hasPremiumAccess({
-      plan: billingStatusTop.plan,
-      subscriptionStatus: billingStatusTop.subscriptionStatus,
-      currentPeriodEnd: billingStatusTop.currentPeriodEnd,
-    });
+    return hasPremiumSettingsAccess(billingStatus);
   };
 
   const canManageCustomDomainFeature = () => {
-    if (!billingStatusTop) return false;
-    return isPremiumUser() || Boolean(billingStatusTop.customDomainGrandfathered);
+    return canManageCustomDomainSettings(billingStatus);
   };
 
   // Update URL when category changes
@@ -1030,7 +1038,6 @@ const Settings = () => {
   const { data: quickResponsesData, isLoading: isLoadingQuickResponses } = useQuickResponses();
   const { data: statusThresholdsData, isLoading: isLoadingStatusThresholds } = useStatusThresholds();
   const { data: ticketLabelSettingsData, isLoading: isLoadingTicketLabels } = useTicketLabelSettings();
-  const { data: billingStatus } = useBillingStatus();
   const { data: usageData } = useUsageData();
   const [currentEmail, setCurrentEmail] = useState('');
 
@@ -3328,6 +3335,33 @@ const Settings = () => {
           </div>
         </div>
 
+        {isBillingAccessPending ? (
+          <>
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-5">
+              {Array.from({ length: 5 }).map((_, index) => (
+                <Card key={index} className="rounded-card shadow-card">
+                  <CardContent className="p-5">
+                    <div className="flex flex-col items-center text-center space-y-3">
+                      <Skeleton className="h-14 w-14 rounded-card" />
+                      <Skeleton className="h-4 w-24" />
+                      <Skeleton className="h-8 w-full" />
+                      <Skeleton className="h-8 w-full" />
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+
+            <Card className="rounded-card shadow-card">
+              <CardContent className="p-8 space-y-4">
+                <Skeleton className="h-6 w-48" />
+                <Skeleton className="h-24 w-full" />
+                <Skeleton className="h-24 w-full" />
+              </CardContent>
+            </Card>
+          </>
+        ) : (
+          <>
         {/* Category Cards Grid */}
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-5">
           {settingsCategories.map((category) => {
@@ -3680,6 +3714,8 @@ const Settings = () => {
           <>
             {expandedSubCategory === 'knowledgebase-articles' && <KnowledgebaseSettings />}
             {expandedSubCategory === 'homepage-cards' && <HomepageCardSettings />}
+          </>
+        )}
           </>
         )}
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are a clean refactor with no logic regressions.

No P0 or P1 issues found. The only observation is a redundant flag in the isBillingAccessPending expression, which has no behavioural effect.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| client/src/lib/settings-access.ts | New utility module extracting three billing-access predicates from settings.tsx; clean, well-typed, and correctly handles undefined billing status. |
| client/src/lib/settings-access.test.ts | New test file covering the three exported functions with happy-path and undefined-input cases. |
| client/src/pages/settings.tsx | Removes duplicate useBillingStatus() call, consolidates billing access logic to use new utility functions, and adds a skeleton loading state guarded by isBillingAccessPending. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aclient%2Fsrc%2Fpages%2Fsettings.tsx%3A728-731%0A**%60isFetchingBillingStatus%60%20is%20redundant%20in%20this%20expression**%0A%0A%60isSettingsBillingPending%60%20already%20short-circuits%20to%20%60false%60%20whenever%20%60billingStatus%60%20is%20defined%2C%20so%20the%20%60isFetchingBillingStatus%60%20flag%20%28which%20is%20%60true%60%20during%20background%20refetches%20when%20data%20already%20exists%29%20never%20has%20a%20different%20effect%20than%20%60isBillingStatusLoading%60%20alone.%20Passing%20just%20%60isBillingStatusLoading%60%20keeps%20the%20intent%20clearer.%0A%0A%60%60%60suggestion%0A%20%20const%20isBillingAccessPending%20%3D%20isSettingsBillingPending%28%0A%20%20%20%20billingStatus%2C%0A%20%20%20%20isBillingStatusLoading%0A%20%20%29%3B%0A%60%60%60%0A%0A&repo=modl-gg%2Fpanel&pr=99&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into dev"](https://github.com/modl-gg/panel/commit/c8a9107b9cc7ec36c31f3da27e91895c3aed847b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29376211)</sub>

<!-- /greptile_comment -->